### PR TITLE
Enable spotify docker maven plugin with modifications 

### DIFF
--- a/docker/portal/pom.xml
+++ b/docker/portal/pom.xml
@@ -59,25 +59,24 @@
                 </configuration>
             </plugin>
 
-            <!-- TODO: Temporarily comment out Docker build for Release 0.1.0 -->
             <!-- Build Docker Image -->
-            <!--<plugin>-->
-                <!--<groupId>com.spotify</groupId>-->
-                <!--<artifactId>dockerfile-maven-plugin</artifactId>-->
-                <!--<executions>-->
-                    <!--<execution>-->
-                        <!--<id>docker-build</id>-->
-                        <!--<phase>package</phase>-->
-                        <!--<goals>-->
-                            <!--<goal>build</goal>-->
-                        <!--</goals>-->
-                        <!--<configuration>-->
-                            <!--<repository>${docker.repo.name}/observability-portal</repository>-->
-                            <!--<tag>${docker.image.tag}</tag>-->
-                        <!--</configuration>-->
-                    <!--</execution>-->
-                <!--</executions>-->
-            <!--</plugin>-->
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>dockerfile-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>docker-build</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                        <configuration>
+                            <repository>${docker.repo.name}/observability-portal</repository>
+                            <tag>${docker.image.tag}</tag>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>

--- a/docker/portal/pom.xml
+++ b/docker/portal/pom.xml
@@ -39,7 +39,7 @@
                 <executions>
                     <execution>
                         <id>copy-observability-portal-app</id>
-                        <phase>package</phase>
+                        <phase>initialize</phase>
                         <goals>
                             <goal>unpack</goal>
                         </goals>

--- a/docker/sp/pom.xml
+++ b/docker/sp/pom.xml
@@ -262,25 +262,24 @@
                 </dependencies>
             </plugin>
 
-            <!-- TODO: Temporarily comment out Docker build for Release 0.1.0 -->
             <!-- Build Docker Image -->
-            <!--<plugin>-->
-                <!--<groupId>com.spotify</groupId>-->
-                <!--<artifactId>dockerfile-maven-plugin</artifactId>-->
-                <!--<executions>-->
-                    <!--<execution>-->
-                        <!--<id>docker-build</id>-->
-                        <!--<phase>package</phase>-->
-                        <!--<goals>-->
-                            <!--<goal>build</goal>-->
-                        <!--</goals>-->
-                        <!--<configuration>-->
-                            <!--<repository>${docker.repo.name}/sp-worker</repository>-->
-                            <!--<tag>${docker.image.tag}</tag>-->
-                        <!--</configuration>-->
-                    <!--</execution>-->
-                <!--</executions>-->
-            <!--</plugin>-->
+            <plugin>
+                <groupId>com.spotify</groupId>
+                <artifactId>dockerfile-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>docker-build</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>build</goal>
+                        </goals>
+                        <configuration>
+                            <repository>${docker.repo.name}/sp-worker</repository>
+                            <tag>${docker.image.tag}</tag>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
## Purpose
> To enable the disabled spotify docker plugin and change the dependency copying phase to initialize. 