### PR TITLE
Disable docker plugin to avoid release build failure

### DIFF
--- a/docker/portal/pom.xml
+++ b/docker/portal/pom.xml
@@ -60,23 +60,23 @@
             </plugin>
 
             <!-- Build Docker Image -->
-            <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>docker-build</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>build</goal>
-                        </goals>
-                        <configuration>
-                            <repository>${docker.repo.name}/observability-portal</repository>
-                            <tag>${docker.image.tag}</tag>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
+            <!--<plugin>-->
+                <!--<groupId>com.spotify</groupId>-->
+                <!--<artifactId>dockerfile-maven-plugin</artifactId>-->
+                <!--<executions>-->
+                    <!--<execution>-->
+                        <!--<id>docker-build</id>-->
+                        <!--<phase>package</phase>-->
+                        <!--<goals>-->
+                            <!--<goal>build</goal>-->
+                        <!--</goals>-->
+                        <!--<configuration>-->
+                            <!--<repository>${docker.repo.name}/observability-portal</repository>-->
+                            <!--<tag>${docker.image.tag}</tag>-->
+                        <!--</configuration>-->
+                    <!--</execution>-->
+                <!--</executions>-->
+            <!--</plugin>-->
         </plugins>
     </build>
 </project>

--- a/docker/sp/pom.xml
+++ b/docker/sp/pom.xml
@@ -263,23 +263,23 @@
             </plugin>
 
             <!-- Build Docker Image -->
-            <plugin>
-                <groupId>com.spotify</groupId>
-                <artifactId>dockerfile-maven-plugin</artifactId>
-                <executions>
-                    <execution>
-                        <id>docker-build</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>build</goal>
-                        </goals>
-                        <configuration>
-                            <repository>${docker.repo.name}/sp-worker</repository>
-                            <tag>${docker.image.tag}</tag>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
+            <!--<plugin>-->
+                <!--<groupId>com.spotify</groupId>-->
+                <!--<artifactId>dockerfile-maven-plugin</artifactId>-->
+                <!--<executions>-->
+                    <!--<execution>-->
+                        <!--<id>docker-build</id>-->
+                        <!--<phase>package</phase>-->
+                        <!--<goals>-->
+                            <!--<goal>build</goal>-->
+                        <!--</goals>-->
+                        <!--<configuration>-->
+                            <!--<repository>${docker.repo.name}/sp-worker</repository>-->
+                            <!--<tag>${docker.image.tag}</tag>-->
+                        <!--</configuration>-->
+                    <!--</execution>-->
+                <!--</executions>-->
+            <!--</plugin>-->
         </plugins>
     </build>
 </project>


### PR DESCRIPTION
## Purpose
> Release build fails in the deploy phase with the spotify maven plugin due to an incompatibility with the maven version.