### PR TITLE
Add kubernetes mock server for unit test execution

### DIFF
--- a/components/global/core/io.cellery.observability.k8s.client/pom.xml
+++ b/components/global/core/io.cellery.observability.k8s.client/pom.xml
@@ -55,6 +55,11 @@
             <artifactId>bcpkix-jdk15on</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.fabric8</groupId>
+            <artifactId>kubernetes-server-mock</artifactId>
+            <scope>test</scope>
+        </dependency>
         <!-- Test dependencies end here -->
     </dependencies>
 

--- a/components/global/core/io.cellery.observability.k8s.client/src/main/java/io/cellery/observability/k8s/client/Constants.java
+++ b/components/global/core/io.cellery.observability.k8s.client/src/main/java/io/cellery/observability/k8s/client/Constants.java
@@ -23,7 +23,6 @@ package io.cellery.observability.k8s.client;
  */
 public class Constants {
     public static final String NAMESPACE = "default";
-    public static final String NODE_NAME = "node1";
     public static final String CELL_NAME_LABEL = "mesh.cellery.io/cell";
     public static final String COMPONENT_NAME_LABEL = "mesh.cellery.io/service";
     public static final String GATEWAY_NAME_LABEL = "mesh.cellery.io/gateway";

--- a/components/global/core/io.cellery.observability.k8s.client/src/main/java/io/cellery/observability/k8s/client/Constants.java
+++ b/components/global/core/io.cellery.observability.k8s.client/src/main/java/io/cellery/observability/k8s/client/Constants.java
@@ -23,6 +23,7 @@ package io.cellery.observability.k8s.client;
  */
 public class Constants {
     public static final String NAMESPACE = "default";
+    public static final String NODE_NAME = "node1";
     public static final String CELL_NAME_LABEL = "mesh.cellery.io/cell";
     public static final String COMPONENT_NAME_LABEL = "mesh.cellery.io/service";
     public static final String GATEWAY_NAME_LABEL = "mesh.cellery.io/gateway";

--- a/components/global/core/io.cellery.observability.k8s.client/src/main/java/io/cellery/observability/k8s/client/K8sClientHolder.java
+++ b/components/global/core/io.cellery.observability.k8s.client/src/main/java/io/cellery/observability/k8s/client/K8sClientHolder.java
@@ -1,0 +1,44 @@
+/*
+ *  Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *  WSO2 Inc. licenses this file to you under the Apache License,
+ *  Version 2.0 (the "License"); you may not use this file except
+ *  in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ */
+package io.cellery.observability.k8s.client;
+
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+
+/**
+ * This class will hold the instance of the k8sClient that is used in the {@link GetComponentPodsStreamProcessor}
+ * stream processor extension.
+ */
+public class K8sClientHolder {
+    private static KubernetesClient k8sClient;
+
+    private K8sClientHolder() {
+    }
+
+    static void setK8sClient(KubernetesClient client) {
+        k8sClient = client;
+    }
+
+    static synchronized KubernetesClient getK8sClient() {
+        if (k8sClient == null) {
+            k8sClient = new DefaultKubernetesClient();
+        }
+        return k8sClient;
+    }
+
+}

--- a/components/global/core/io.cellery.observability.k8s.client/src/test/java/io/cellery/observability/k8s/client/BaseTestCase.java
+++ b/components/global/core/io.cellery.observability.k8s.client/src/test/java/io/cellery/observability/k8s/client/BaseTestCase.java
@@ -37,6 +37,8 @@ public class BaseTestCase {
     protected static final String TEST_LABEL = "mesh-observability-test";
     protected static final int WAIT_TIME = 50;
     protected static final int TIMEOUT = 5000;
+    protected static final String NODE_NAME = "node1";
+
 
     protected KubernetesClient k8sClient;
     protected KubernetesServer k8sServer;
@@ -49,6 +51,7 @@ public class BaseTestCase {
         k8sClient.getConfiguration().setNamespace(Constants.NAMESPACE);
         k8sClient.namespaces().list();     // To validate if the access to the K8s cluster is accurate
         K8sClientHolder.setK8sClient(k8sClient);
+        k8sClient.nodes().createNew().withNewMetadata().withName(NODE_NAME).endMetadata().done();
     }
 
     @AfterClass
@@ -140,7 +143,7 @@ public class BaseTestCase {
                 .addToLabels(labels)
                 .endMetadata()
                 .withNewSpec()
-                .withNodeName(Constants.NODE_NAME)
+                .withNodeName(NODE_NAME)
                 .addNewContainer()
                 .withName("test-container")
                 .withNewImage(container)

--- a/components/global/core/io.cellery.observability.k8s.client/src/test/java/io/cellery/observability/k8s/client/GetComponentPodsStreamProcessorTestCase.java
+++ b/components/global/core/io.cellery.observability.k8s.client/src/test/java/io/cellery/observability/k8s/client/GetComponentPodsStreamProcessorTestCase.java
@@ -55,7 +55,6 @@ public class GetComponentPodsStreamProcessorTestCase extends BaseTestCase {
 
     @BeforeClass
     public void initTestCase() {
-        k8sClient.nodes().createNew().withNewMetadata().withName(Constants.NODE_NAME).endMetadata().done();
         nodeValues = k8sClient.nodes()
                 .list()
                 .getItems()

--- a/pom.xml
+++ b/pom.xml
@@ -341,6 +341,12 @@
                 <version>${powermock.version}</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>io.fabric8</groupId>
+                <artifactId>kubernetes-server-mock</artifactId>
+                <version>${fabric8.kubernetes.version}</version>
+                <scope>test</scope>
+            </dependency>
             <!-- Test dependencies end here -->
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
The current unit tests require the kubernetes setup to be up and running, and it's bit heavy to have the k8s setup for unit tests. Hence, with this PR it uses the kubernetes mock server. 