### PR TITLE
Update the Cell and Component name resolution to use K8s Labels taken from API Servers 🔨

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,30 +1,14 @@
-dist: xenial
-sudo: required
 language: java
 jdk:
   - openjdk8
-addons:
-  apt:
-    update: true
-    packages:
-      - docker-ce
-env:
-  - CHANGE_MINIKUBE_NONE_USER=true
+services:
+  - docker
 cache:
   directories:
     - .autoconf
     - $HOME/.m2
 before_install:
   - npm i -g npm
-  # Installing crictl (Required for minikube)
-  - wget https://github.com/kubernetes-sigs/cri-tools/releases/download/v1.11.1/crictl-v1.11.1-linux-amd64.tar.gz
-  - sudo tar zxvf crictl-v1.11.1-linux-amd64.tar.gz -C /usr/local/bin
-  - rm -f crictl-v1.11.1-linux-amd64.tar.gz
-  # Creating a single node K8s Cluster
-  - curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.11.9/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
-  - curl -Lo minikube https://storage.googleapis.com/minikube/releases/latest/minikube-linux-amd64 && chmod +x minikube && sudo mv minikube /usr/local/bin/
-  - sudo minikube start --vm-driver=none --kubernetes-version=v1.11.9
-  - minikube update-context
 script:
   - mvn clean install
   - make docker

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_install:
   - sudo minikube start --vm-driver=none --kubernetes-version=v1.11.9
   - minikube update-context
 script:
-  - mvn clean install -P kubernetes-tests
+  - mvn clean install
   - make docker
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/components/global/core/io.cellery.observability.k8s.client/pom.xml
+++ b/components/global/core/io.cellery.observability.k8s.client/pom.xml
@@ -44,6 +44,10 @@
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-client</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+        </dependency>
 
         <!-- Test dependencies start here -->
         <dependency>

--- a/components/global/core/io.cellery.observability.k8s.client/pom.xml
+++ b/components/global/core/io.cellery.observability.k8s.client/pom.xml
@@ -81,13 +81,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <configuration>
-                    <!--
-                        Disable in favour of kubernetes-tests profile. This is required since the root WSO2 POM
-                        adds the maven surefire plugin by default.
-                    -->
-                    <skipTests>true</skipTests>
-                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
             </plugin>
             <plugin>
                 <groupId>org.apache.felix</groupId>
@@ -112,24 +109,4 @@
             </plugin>
         </plugins>
     </build>
-
-    <profiles>
-        <profile>
-            <id>kubernetes-tests</id>
-            <activation>
-                <activeByDefault>false</activeByDefault>
-            </activation>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-surefire-plugin</artifactId>
-                        <configuration>
-                            <skipTests>false</skipTests>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-    </profiles>
 </project>

--- a/components/global/core/io.cellery.observability.k8s.client/pom.xml
+++ b/components/global/core/io.cellery.observability.k8s.client/pom.xml
@@ -55,6 +55,10 @@
             <artifactId>testng</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-all</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>
             <scope>test</scope>
@@ -62,6 +66,11 @@
         <dependency>
             <groupId>io.fabric8</groupId>
             <artifactId>kubernetes-server-mock</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.wso2.extension.siddhi.map.keyvalue</groupId>
+            <artifactId>siddhi-map-keyvalue</artifactId>
             <scope>test</scope>
         </dependency>
         <!-- Test dependencies end here -->

--- a/components/global/core/io.cellery.observability.k8s.client/pom.xml
+++ b/components/global/core/io.cellery.observability.k8s.client/pom.xml
@@ -59,6 +59,10 @@
             <artifactId>mockito-all</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.powermock</groupId>
+            <artifactId>powermock-module-testng</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>
             <scope>test</scope>

--- a/components/global/core/io.cellery.observability.k8s.client/src/main/java/io/cellery/observability/k8s/client/ComponentPodsEventSource.java
+++ b/components/global/core/io.cellery.observability.k8s.client/src/main/java/io/cellery/observability/k8s/client/ComponentPodsEventSource.java
@@ -19,7 +19,6 @@
 package io.cellery.observability.k8s.client;
 
 import io.fabric8.kubernetes.api.model.Pod;
-import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
 import io.fabric8.kubernetes.client.Watch;
@@ -87,9 +86,9 @@ public class ComponentPodsEventSource extends Source {
     @Override
     public void connect(ConnectionCallback connectionCallback) {
         // Initializing the K8s API Client
-        k8sClient = new DefaultKubernetesClient();
+        k8sClient = K8sClientHolder.getK8sClient();
         if (logger.isDebugEnabled()) {
-            logger.debug("Created API server client");
+            logger.debug("Retrieved API server client instance");
         }
 
         // Pod watcher for Cellery components

--- a/components/global/core/io.cellery.observability.k8s.client/src/main/java/io/cellery/observability/k8s/client/ComponentPodsEventSource.java
+++ b/components/global/core/io.cellery.observability.k8s.client/src/main/java/io/cellery/observability/k8s/client/ComponentPodsEventSource.java
@@ -180,10 +180,14 @@ public class ComponentPodsEventSource extends Source {
                 attributes.put(ATTRIBUTE_CELL, pod.getMetadata().getLabels().get(Constants.CELL_NAME_LABEL));
                 attributes.put(ATTRIBUTE_COMPONENT, Utils.getComponentName(pod));
                 attributes.put(ATTRIBUTE_POD_NAME, pod.getMetadata().getName());
-                attributes.put(ATTRIBUTE_CREATION_TIMESTAMP,
-                        new SimpleDateFormat(Constants.K8S_DATE_FORMAT, Locale.US)
-                                .parse(pod.getMetadata().getCreationTimestamp()).getTime());
-                attributes.put(ATTRIBUTE_DELETION_TIMESTAMP, pod.getMetadata().getDeletionTimestamp());
+                attributes.put(ATTRIBUTE_CREATION_TIMESTAMP, pod.getMetadata().getCreationTimestamp() == null
+                        ? -1
+                        : new SimpleDateFormat(Constants.K8S_DATE_FORMAT, Locale.US).parse(
+                                pod.getMetadata().getCreationTimestamp()).getTime());
+                attributes.put(ATTRIBUTE_DELETION_TIMESTAMP, pod.getMetadata().getDeletionTimestamp() == null
+                        ? -1
+                        : new SimpleDateFormat(Constants.K8S_DATE_FORMAT, Locale.US).parse(
+                                pod.getMetadata().getDeletionTimestamp()).getTime());
                 attributes.put(ATTRIBUTE_NODE_NAME,
                         pod.getSpec().getNodeName() == null ? "" : pod.getSpec().getNodeName());
                 attributes.put(ATTRIBUTE_STATUS, pod.getStatus().getPhase());

--- a/components/global/core/io.cellery.observability.k8s.client/src/main/java/io/cellery/observability/k8s/client/ComponentPodsEventSource.java
+++ b/components/global/core/io.cellery.observability.k8s.client/src/main/java/io/cellery/observability/k8s/client/ComponentPodsEventSource.java
@@ -1,0 +1,220 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.cellery.observability.k8s.client;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.Watcher;
+import org.apache.log4j.Logger;
+import org.wso2.siddhi.annotation.Example;
+import org.wso2.siddhi.annotation.Extension;
+import org.wso2.siddhi.core.config.SiddhiAppContext;
+import org.wso2.siddhi.core.stream.input.source.Source;
+import org.wso2.siddhi.core.stream.input.source.SourceEventListener;
+import org.wso2.siddhi.core.util.config.ConfigReader;
+import org.wso2.siddhi.core.util.transport.OptionHolder;
+
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/**
+ * This class implements the Event Source which can be used to listen for k8s pod changes.
+ */
+@Extension(
+        name = "k8s-component-pods",
+        namespace = "source",
+        description = "This is an event source which emits events upon changes to Cellery Components deployed as" +
+                "Kubernetes Pods",
+        examples = {
+                @Example(
+                        syntax = "@source(type='k8s-component-pods', @map(type='keyvalue', " +
+                                "fail.on.missing.attribute='false'))\n" +
+                                "define stream K8sPodEvents (cell string, component string, name string, " +
+                                "creationTimestamp long, nodeName string, status string, action string)",
+                        description = "This will listen for kubernetes pod events and emit events upon changes " +
+                                "to the pods"
+                )
+        }
+)
+public class ComponentPodsEventSource extends Source {
+
+    private static final Logger logger = Logger.getLogger(ComponentPodsEventSource.class.getName());
+
+    private static final String ATTRIBUTE_CELL = "cell";
+    private static final String ATTRIBUTE_COMPONENT = "component";
+    private static final String ATTRIBUTE_POD_NAME = "name";
+    private static final String ATTRIBUTE_CREATION_TIMESTAMP = "creationTimestamp";
+    private static final String ATTRIBUTE_DELETION_TIMESTAMP = "deletionTimestamp";
+    private static final String ATTRIBUTE_NODE_NAME = "nodeName";
+    private static final String ATTRIBUTE_STATUS = "status";
+    private static final String ATTRIBUTE_ACTION = "action";
+
+    private KubernetesClient k8sClient;
+    private SourceEventListener sourceEventListener;
+    private List<Watch> k8sWatches;
+
+    @Override
+    public void init(SourceEventListener sourceEventListener, OptionHolder optionHolder, String[] strings,
+                     ConfigReader configReader, SiddhiAppContext siddhiAppContext) {
+        this.k8sWatches = new ArrayList<>(2);
+        this.sourceEventListener = sourceEventListener;
+    }
+
+    @Override
+    public void connect(ConnectionCallback connectionCallback) {
+        // Initializing the K8s API Client
+        k8sClient = new DefaultKubernetesClient();
+        if (logger.isDebugEnabled()) {
+            logger.debug("Created API server client");
+        }
+
+        // Pod watcher for Cellery components
+        Watch componentsWatch = k8sClient.pods()
+                .inNamespace(Constants.NAMESPACE)
+                .withLabel(Constants.CELL_NAME_LABEL)
+                .withLabel(Constants.COMPONENT_NAME_LABEL)
+                .watch(new PodWatcher(this.sourceEventListener, Constants.COMPONENT_NAME_LABEL));
+        k8sWatches.add(componentsWatch);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Created pod watcher for components");
+        }
+        // Pod watcher for Cellery cell gateways
+        Watch gatewaysWatch = k8sClient.pods()
+                .inNamespace(Constants.NAMESPACE)
+                .withLabel(Constants.CELL_NAME_LABEL)
+                .withLabel(Constants.GATEWAY_NAME_LABEL)
+                .watch(new PodWatcher(this.sourceEventListener, Constants.GATEWAY_NAME_LABEL));
+        k8sWatches.add(gatewaysWatch);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Created pod watcher for gateways");
+        }
+    }
+
+    @Override
+    public void disconnect() {
+        while (k8sWatches.size() > 0) {
+            Watch watch = k8sWatches.remove(0);
+            watch.close();
+        }
+        if (k8sClient != null) {
+            k8sClient.close();
+            if (logger.isDebugEnabled()) {
+                logger.debug("Closed API server client");
+            }
+        }
+    }
+
+    @Override
+    public void destroy() {
+        // Do nothing
+    }
+
+    @Override
+    public void pause() {
+        // Do nothing
+    }
+
+    @Override
+    public void resume() {
+        // Do nothing
+    }
+
+    @Override
+    public Map<String, Object> currentState() {
+        // Do nothing
+        return null;
+    }
+
+    @Override
+    public void restoreState(Map<String, Object> state) {
+        // Do nothing
+    }
+
+    @Override
+    public Class[] getOutputEventClasses() {
+        return new Class[]{Map.class};
+    }
+
+    /**
+     * Pod watcher which can listen for pod changes and create events based on them.
+     */
+    private static class PodWatcher implements Watcher<Pod> {
+
+        private static final Logger logger = Logger.getLogger(PodWatcher.class.getName());
+        private final SourceEventListener sourceEventListener;
+        private final String componentNameLabel;
+
+        PodWatcher(SourceEventListener sourceEventListener, String componentNameLabel) {
+            this.sourceEventListener = sourceEventListener;
+            this.componentNameLabel = componentNameLabel;
+        }
+
+        @Override
+        public void eventReceived(Action action, Pod pod) {
+            try {
+                Map<String, Object> attributes = new HashMap<>();
+                attributes.put(ATTRIBUTE_CELL, pod.getMetadata().getLabels().get(Constants.CELL_NAME_LABEL));
+                attributes.put(ATTRIBUTE_COMPONENT, Utils.getComponentName(pod));
+                attributes.put(ATTRIBUTE_POD_NAME, pod.getMetadata().getName());
+                attributes.put(ATTRIBUTE_CREATION_TIMESTAMP,
+                        new SimpleDateFormat(Constants.K8S_DATE_FORMAT, Locale.US)
+                                .parse(pod.getMetadata().getCreationTimestamp()).getTime());
+                attributes.put(ATTRIBUTE_DELETION_TIMESTAMP, pod.getMetadata().getDeletionTimestamp());
+                attributes.put(ATTRIBUTE_NODE_NAME,
+                        pod.getSpec().getNodeName() == null ? "" : pod.getSpec().getNodeName());
+                attributes.put(ATTRIBUTE_STATUS, pod.getStatus().getPhase());
+                attributes.put(ATTRIBUTE_ACTION, action.toString());
+
+                sourceEventListener.onEvent(attributes, new String[0]);
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Emitted event - pod " + pod.getMetadata().getName() + " with resource version " +
+                            pod.getMetadata().getCreationTimestamp() + " belonging to cell " +
+                            pod.getMetadata().getLabels().get(Constants.CELL_NAME_LABEL) + " of type " +
+                            (Constants.COMPONENT_NAME_LABEL.equals(componentNameLabel) ? "component" : "gateway"));
+                }
+            } catch (ParseException e) {
+                // This should not happen unless the K8s date-time format changed (eg:- K8s version upgrade)
+                logger.error("Ignored pod change due to creation timestamp parse failure", e);
+            }
+        }
+
+        @Override
+        public void onClose(KubernetesClientException cause) {
+            if (cause == null) {
+                if (logger.isDebugEnabled()) {
+                    logger.debug("Kubernetes " +
+                            (Constants.COMPONENT_NAME_LABEL.equals(componentNameLabel) ? "component" : "gateway") +
+                            " pod watcher closed successfully");
+                }
+            } else {
+                logger.error("Kubernetes " +
+                        (Constants.COMPONENT_NAME_LABEL.equals(componentNameLabel) ? "component" : "gateway") +
+                        " pod watcher closed with error", cause);
+            }
+        }
+    }
+}

--- a/components/global/core/io.cellery.observability.k8s.client/src/main/java/io/cellery/observability/k8s/client/Constants.java
+++ b/components/global/core/io.cellery.observability.k8s.client/src/main/java/io/cellery/observability/k8s/client/Constants.java
@@ -22,6 +22,7 @@ package io.cellery.observability.k8s.client;
  * This contains the constants for the K8S Client Extensions
  */
 public class Constants {
+
     public static final String NAMESPACE = "default";
     public static final String CELL_NAME_LABEL = "mesh.cellery.io/cell";
     public static final String COMPONENT_NAME_LABEL = "mesh.cellery.io/service";

--- a/components/global/core/io.cellery.observability.k8s.client/src/main/java/io/cellery/observability/k8s/client/GetComponentPodsStreamProcessor.java
+++ b/components/global/core/io.cellery.observability.k8s.client/src/main/java/io/cellery/observability/k8s/client/GetComponentPodsStreamProcessor.java
@@ -91,7 +91,7 @@ public class GetComponentPodsStreamProcessor extends StreamProcessor {
     public void start() {
         k8sClient = K8sClientHolder.getK8sClient();
         if (logger.isDebugEnabled()) {
-            logger.debug("Created API server client");
+            logger.debug("Retrieved API server client instance");
         }
     }
 
@@ -167,19 +167,17 @@ public class GetComponentPodsStreamProcessor extends StreamProcessor {
                             " to the event");
                 }
 
-                if (pod.getMetadata().getLabels().containsKey(componentNameLabel)) {
-                    Object[] newData = new Object[5];
-                    newData[0] = pod.getMetadata().getLabels().getOrDefault(Constants.CELL_NAME_LABEL, "");
-                    newData[1] = Utils.getComponentName(pod);
-                    newData[2] = pod.getMetadata().getName();
-                    newData[3] = new SimpleDateFormat(Constants.K8S_DATE_FORMAT, Locale.US)
-                            .parse(pod.getMetadata().getCreationTimestamp()).getTime();
-                    newData[4] = pod.getSpec().getNodeName();
+                Object[] newData = new Object[5];
+                newData[0] = pod.getMetadata().getLabels().getOrDefault(Constants.CELL_NAME_LABEL, "");
+                newData[1] = Utils.getComponentName(pod);
+                newData[2] = pod.getMetadata().getName();
+                newData[3] = new SimpleDateFormat(Constants.K8S_DATE_FORMAT, Locale.US)
+                        .parse(pod.getMetadata().getCreationTimestamp()).getTime();
+                newData[4] = pod.getSpec().getNodeName();
 
-                    StreamEvent streamEventCopy = streamEventCloner.copyStreamEvent(incomingStreamEvent);
-                    complexEventPopulater.populateComplexEvent(streamEventCopy, newData);
-                    outputStreamEventChunk.add(streamEventCopy);
-                }
+                StreamEvent streamEventCopy = streamEventCloner.copyStreamEvent(incomingStreamEvent);
+                complexEventPopulater.populateComplexEvent(streamEventCopy, newData);
+                outputStreamEventChunk.add(streamEventCopy);
             }
         }
     }

--- a/components/global/core/io.cellery.observability.k8s.client/src/main/java/io/cellery/observability/k8s/client/GetComponentPodsStreamProcessor.java
+++ b/components/global/core/io.cellery.observability.k8s.client/src/main/java/io/cellery/observability/k8s/client/GetComponentPodsStreamProcessor.java
@@ -45,13 +45,16 @@ import java.util.Locale;
 import java.util.Map;
 
 /**
- * This class implements the Stream Processor which can be used to call the K8s API Server and get data about Pods.
+ * This class implements the Stream Processor which can be used to call the K8s API Server and get data about Cellery
+ * Component pods deployed in a namespace.
  */
 @Extension(
         name = "getComponentPods",
         namespace = "k8sClient",
         description = "This is a client which calls the Kubernetes API server based on the received parameters and " +
-                "adds the pod details received. This read the Service Account Token loaded into the pod and calls " +
+                "adds the pod details received. Each pod will be a separate event duplicated from the original event" +
+                "sent to this stream processor. If m number of multiple events are sent while n pods are present," +
+                "m x n events will be sent out. This read the Service Account Token loaded into the pod and calls " +
                 "the API Server using that.",
         examples = {
                 @Example(
@@ -71,8 +74,8 @@ public class GetComponentPodsStreamProcessor extends StreamProcessor {
                                    SiddhiAppContext siddhiAppContext) {
         int attributeLength = attributeExpressionExecutors.length;
         if (attributeLength != 0) {
-            throw new SiddhiAppValidationException("k8sClient expects exactly zero input parameters, but " +
-                    attributeExpressionExecutors.length + " attributes found");
+            throw new SiddhiAppValidationException("k8sClient:getComponentPods() expects exactly zero input " +
+                    "parameters, but " + attributeExpressionExecutors.length + " attributes found");
         }
 
         List<Attribute> appendedAttributes = new ArrayList<>();
@@ -123,6 +126,7 @@ public class GetComponentPodsStreamProcessor extends StreamProcessor {
                 addComponentPods(outputStreamEventChunk, incomingStreamEvent, Constants.COMPONENT_NAME_LABEL);
                 addComponentPods(outputStreamEventChunk, incomingStreamEvent, Constants.GATEWAY_NAME_LABEL);
             } catch (ParseException e) {
+                // This should not happen unless the K8s date-time format changed (eg:- K8s version upgrade)
                 logger.error("Failed to parse K8s timestamp", e);
             }
         }
@@ -165,8 +169,8 @@ public class GetComponentPodsStreamProcessor extends StreamProcessor {
 
                 if (pod.getMetadata().getLabels().containsKey(componentNameLabel)) {
                     Object[] newData = new Object[5];
-                    newData[0] = pod.getMetadata().getLabels().get(Constants.CELL_NAME_LABEL);
-                    newData[1] = getComponentName(pod.getMetadata().getLabels().get(componentNameLabel));
+                    newData[0] = pod.getMetadata().getLabels().getOrDefault(Constants.CELL_NAME_LABEL, "");
+                    newData[1] = Utils.getComponentName(pod);
                     newData[2] = pod.getMetadata().getName();
                     newData[3] = new SimpleDateFormat(Constants.K8S_DATE_FORMAT, Locale.US)
                             .parse(pod.getMetadata().getCreationTimestamp()).getTime();
@@ -178,19 +182,5 @@ public class GetComponentPodsStreamProcessor extends StreamProcessor {
                 }
             }
         }
-    }
-
-    /**
-     * Get the actual component name from the fully qualified name.
-     *
-     * @param fullyQualifiedName The fully qualified name (eg:- "hr--hr")
-     * @return The actual component name
-     */
-    private String getComponentName(String fullyQualifiedName) {
-        String componentName = fullyQualifiedName;
-        if (fullyQualifiedName.contains("--")) {
-            componentName = fullyQualifiedName.split("--")[1];
-        }
-        return componentName;
     }
 }

--- a/components/global/core/io.cellery.observability.k8s.client/src/main/java/io/cellery/observability/k8s/client/K8sClientHolder.java
+++ b/components/global/core/io.cellery.observability.k8s.client/src/main/java/io/cellery/observability/k8s/client/K8sClientHolder.java
@@ -19,24 +19,26 @@ package io.cellery.observability.k8s.client;
 
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import org.apache.log4j.Logger;
 
 /**
  * This class will hold the instance of the k8sClient that is used in the {@link GetComponentPodsStreamProcessor}
  * stream processor extension.
  */
 public class K8sClientHolder {
+
+    private static final Logger logger = Logger.getLogger(K8sClientHolder.class.getName());
     private static KubernetesClient k8sClient;
 
     private K8sClientHolder() {
     }
 
-    static void setK8sClient(KubernetesClient client) {
-        k8sClient = client;
-    }
-
     static synchronized KubernetesClient getK8sClient() {
         if (k8sClient == null) {
             k8sClient = new DefaultKubernetesClient();
+            if (logger.isDebugEnabled()) {
+                logger.debug("Created API server client");
+            }
         }
         return k8sClient;
     }

--- a/components/global/core/io.cellery.observability.k8s.client/src/main/java/io/cellery/observability/k8s/client/Utils.java
+++ b/components/global/core/io.cellery.observability.k8s.client/src/main/java/io/cellery/observability/k8s/client/Utils.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.cellery.observability.k8s.client;
+
+import io.fabric8.kubernetes.api.model.Pod;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Map;
+
+/**
+ * Cellery Utilities.
+ */
+public class Utils {
+
+    /**
+     * Get the actual component name of a pod.
+     *
+     * @param pod The kubernetes pod of which the component name should be retrieved
+     * @return The actual component name
+     */
+    public static String getComponentName(Pod pod) {
+        String fullyQualifiedName = null;
+        Map<String, String> labels = pod.getMetadata().getLabels();
+        if (labels.containsKey(Constants.COMPONENT_NAME_LABEL)) {
+            fullyQualifiedName = labels.get(Constants.COMPONENT_NAME_LABEL);
+        } else if (labels.containsKey(Constants.GATEWAY_NAME_LABEL)) {
+            fullyQualifiedName = labels.get(Constants.GATEWAY_NAME_LABEL);
+        }
+
+        String componentName;
+        if (StringUtils.isNotEmpty(fullyQualifiedName) && fullyQualifiedName.contains("--")) {
+            componentName = fullyQualifiedName.split("--")[1];
+        } else {
+            componentName = "";
+        }
+        return componentName;
+    }
+
+    private Utils() {   // Prevent initialization
+    }
+}

--- a/components/global/core/io.cellery.observability.k8s.client/src/test/java/io/cellery/observability/k8s/client/BaseTestCase.java
+++ b/components/global/core/io.cellery.observability.k8s.client/src/test/java/io/cellery/observability/k8s/client/BaseTestCase.java
@@ -19,16 +19,20 @@
 package io.cellery.observability.k8s.client;
 
 import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodBuilder;
+import io.fabric8.kubernetes.api.model.PodStatus;
+import io.fabric8.kubernetes.api.model.PodStatusBuilder;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.server.mock.KubernetesServer;
 import org.apache.log4j.Logger;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
+import org.powermock.reflect.Whitebox;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 
+import java.text.SimpleDateFormat;
 import java.util.HashMap;
-import java.util.List;
+import java.util.Locale;
 import java.util.Map;
-import java.util.stream.Collectors;
 
 /**
  * Base Test Case for K8s Clients.
@@ -40,159 +44,143 @@ public class BaseTestCase {
     protected static final String TEST_LABEL = "mesh-observability-test";
     protected static final int WAIT_TIME = 50;
     protected static final int TIMEOUT = 5000;
-    protected static final String NODE_NAME = "node1";
 
+    protected static final String NODE_NAME = "node1";
+    protected static final String POD_CREATION_TIMESTAMP_STRING = "2019-04-30T13:21:22Z";
+    protected final long podCreationTimestamp;
+
+    public BaseTestCase() throws Exception {
+        podCreationTimestamp = new SimpleDateFormat(Constants.K8S_DATE_FORMAT, Locale.US)
+                .parse(POD_CREATION_TIMESTAMP_STRING).getTime();
+    }
 
     protected KubernetesClient k8sClient;
     protected KubernetesServer k8sServer;
 
-    @BeforeClass
+    @BeforeMethod
     public void initBaseTestCase() {
-        k8sServer = new KubernetesServer(true, true);
+        k8sServer = new KubernetesServer(true, false);
         k8sServer.before();
+        if (logger.isDebugEnabled()) {
+            logger.debug("Started K8s Mock Server");
+        }
+
         k8sClient = k8sServer.getClient();
-        k8sClient.getConfiguration().setNamespace(Constants.NAMESPACE);
-        k8sClient.namespaces().list();     // To validate if the access to the K8s cluster is accurate
-        K8sClientHolder.setK8sClient(k8sClient);
-        k8sClient.nodes().createNew().withNewMetadata().withName(NODE_NAME).endMetadata().done();
+        if (logger.isDebugEnabled()) {
+            logger.debug("Initialized the K8s Client for the K8s Mock Server");
+        }
+        Whitebox.setInternalState(K8sClientHolder.class, "k8sClient", k8sClient);
     }
 
-    @AfterClass
-    public void cleanupTestCase() {
-        cleanUpTestPods();
+    @AfterMethod
+    public void cleanupBaseTestCase() {
         k8sClient.close();
+        if (logger.isDebugEnabled()) {
+            logger.debug("Closed the K8s Client");
+        }
         k8sServer.after();
-    }
-
-    /**
-     * Create and check for a K8s pod creation.
-     *
-     * @param cell      The Cell the Pod belongs to
-     * @param component The component of the Cell the pod belongs to
-     */
-    protected void createCelleryComponentPod(String cell, String component) throws Exception {
-        String podName = cell + "--" + component;
-
-        Map<String, String> labels = new HashMap<>();
-        labels.put(Constants.CELL_NAME_LABEL, cell);
-        labels.put(Constants.COMPONENT_NAME_LABEL, cell + "--" + component);
-
-        createPod(podName, labels, "busybox");
-        checkPodCreation(podName);
-    }
-
-    /**
-     * Create and check for a K8s pod creation.
-     *
-     * @param cell The Cell the Pod belongs to
-     */
-    protected void createCelleryGatewayPod(String cell) throws Exception {
-        String podName = cell + "--gateway";
-
-        Map<String, String> labels = new HashMap<>();
-        labels.put(Constants.CELL_NAME_LABEL, cell);
-        labels.put(Constants.GATEWAY_NAME_LABEL, cell + "--gateway");
-
-        createPod(podName, labels, "busybox");
-        checkPodCreation(podName);
-    }
-
-    /**
-     * Create and check for a K8s pod creation.
-     *
-     * @param podName The name of the normal pod
-     */
-    protected void createNormalPod(String podName) throws Exception {
-        createPod(podName, new HashMap<>(), "busybox");
-        checkPodCreation(podName);
-    }
-
-    /**
-     * Create a cellery component pod that would fail.
-     *
-     * @param cell      The Cell the Pod belongs to
-     * @param component The component of the Cell the pod belongs to
-     */
-    protected void createFailingCelleryComponentPod(String cell, String component) {
-        String podName = cell + "--" + component;
-
-        Map<String, String> labels = new HashMap<>();
-        labels.put(Constants.CELL_NAME_LABEL, cell);
-        labels.put(Constants.COMPONENT_NAME_LABEL, cell + "--" + component);
-
-        createPod(podName, labels, "non-existent-container");
-    }
-
-    /**
-     * Create a cellery gateway pod that would fail.
-     *
-     * @param cell      The Cell the Pod belongs to
-     */
-    protected void createFailingCelleryGatewayPod(String cell) {
-        String podName = cell + "--gateway";
-
-        Map<String, String> labels = new HashMap<>();
-        labels.put(Constants.CELL_NAME_LABEL, cell);
-        labels.put(Constants.GATEWAY_NAME_LABEL, cell + "--gateway");
-
-        createPod(podName, labels, "non-existent-container");
-    }
-
-    /**
-     * Create a pod that would fail.
-     *
-     * @param podName The name of the pod to create
-     */
-    protected void createFailingNormalPod(String podName) {
-        createPod(podName, new HashMap<>(), "non-existent-container");
-    }
-
-    /**
-     * Delete and wait for K8s pod to be removed.
-     *
-     * @param podName The name of the pod to be deleted
-     */
-    protected void deletePod(String podName) {
-        k8sClient.pods()
-                .inNamespace(Constants.NAMESPACE)
-                .withName(podName)
-                .delete();
-        waitForPodRemove(podName);
-    }
-
-    /**
-     * Removes all the test pods created.
-     */
-    protected void cleanUpTestPods() {
-        List<String> podNames = k8sClient.pods()
-                .withLabel(TEST_LABEL)
-                .list()
-                .getItems()
-                .stream()
-                .map((pod) -> pod.getMetadata().getName())
-                .collect(Collectors.toList());
-        k8sClient.pods()
-                .withLabel(TEST_LABEL)
-                .delete();
-        for (String podName : podNames) {
-            waitForPodRemove(podName);
+        if (logger.isDebugEnabled()) {
+            logger.debug("Closed the K8s Mock Server");
         }
     }
 
     /**
-     * Create a pod using the provided labels and container with the provided pod name.
+     * Generate a Cellery Component K8s pod object.
+     * The returned pod can be used as one of the returned pods in K8s Mock Server in expectation mode.
+     *
+     * @param cell      The Cell the Pod belongs to
+     * @param component The component of the Cell the pod belongs to
+     * @return The generated pod
+     */
+    protected Pod generateCelleryComponentPod(String cell, String component) {
+        String podName = cell + "--" + component;
+
+        Map<String, String> labels = new HashMap<>();
+        labels.put(Constants.CELL_NAME_LABEL, cell);
+        labels.put(Constants.COMPONENT_NAME_LABEL, cell + "--" + component);
+
+        PodStatus podStatus = new PodStatusBuilder()
+                .withPhase("Running")
+                .build();
+        return generatePod(podName, labels, podStatus);
+    }
+
+    /**
+     * Generate a Cellery Gateway K8s pod object.
+     * The returned pod can be used as one of the returned pods in K8s Mock Server in expectation mode.
+     *
+     * @param cell The Cell the Pod belongs to
+     * @return The generated pod
+     */
+    protected Pod generateCelleryGatewayPod(String cell) {
+        String podName = cell + "--gateway";
+
+        Map<String, String> labels = new HashMap<>();
+        labels.put(Constants.CELL_NAME_LABEL, cell);
+        labels.put(Constants.GATEWAY_NAME_LABEL, cell + "--gateway");
+
+        PodStatus podStatus = new PodStatusBuilder()
+                .withPhase("Running")
+                .build();
+        return generatePod(podName, labels, podStatus);
+    }
+
+    /**
+     * Generate a Cellery Component K8s pod object with a failing state.
+     * The returned pod can be used as one of the returned pods in K8s Mock Server in expectation mode.
+     *
+     * @param cell      The Cell the Pod belongs to
+     * @param component The component of the Cell the pod belongs to
+     * @return The generated pod
+     */
+    protected Pod generateFailingCelleryComponentPod(String cell, String component) {
+        String podName = cell + "--" + component;
+
+        Map<String, String> labels = new HashMap<>();
+        labels.put(Constants.CELL_NAME_LABEL, cell);
+        labels.put(Constants.COMPONENT_NAME_LABEL, cell + "--" + component);
+
+        PodStatus podStatus = new PodStatusBuilder()
+                .withPhase("ErrImagePull")
+                .build();
+        return generatePod(podName, labels, podStatus);
+    }
+
+    /**
+     * Generate a Cellery Gateway K8s pod object with a failing state.
+     * The returned pod can be used as one of the returned pods in K8s Mock Server in expectation mode.
+     *
+     * @param cell      The Cell the Pod belongs to
+     * @return The generated pod
+     */
+    protected Pod generateFailingCelleryGatewayPod(String cell) {
+        String podName = cell + "--gateway";
+
+        Map<String, String> labels = new HashMap<>();
+        labels.put(Constants.CELL_NAME_LABEL, cell);
+        labels.put(Constants.GATEWAY_NAME_LABEL, cell + "--gateway");
+
+        PodStatus podStatus = new PodStatusBuilder()
+                .withPhase("ErrImagePull")
+                .build();
+        return generatePod(podName, labels, podStatus);
+    }
+
+    /**
+     * Generate a pod using the provided labels and container with the provided pod name.
+     * The returned pod can be used as one of the returned pods in K8s Mock Server in expectation mode.
      *
      * @param podName   The name of the new pod
      * @param labels    The set of labels to apply
-     * @param container The container to use
+     * @param status    The state
+     * @return The generated pod
      */
-    private void createPod(String podName, Map<String, String> labels, String container) {
+    private Pod generatePod(String podName, Map<String, String> labels, PodStatus status) {
         labels.put(TEST_LABEL, "true");
-        k8sClient.pods()
-                .createNew()
+        return new PodBuilder()
                 .withNewMetadata()
                 .withNamespace(Constants.NAMESPACE)
-                .withCreationTimestamp("2019-04-30T13:21:22Z")
+                .withCreationTimestamp(POD_CREATION_TIMESTAMP_STRING)
                 .withName(podName)
                 .addToLabels(labels)
                 .endMetadata()
@@ -200,57 +188,12 @@ public class BaseTestCase {
                 .withNodeName(NODE_NAME)
                 .addNewContainer()
                 .withName("test-container")
-                .withNewImage(container)
+                .withNewImage("busybox")
                 .withNewImagePullPolicy("IfNotPresent")
                 .withCommand("tail", "-f", "/dev/null")
                 .endContainer()
                 .endSpec()
-                .done();
-    }
-
-    /**
-     * Check for a pod creation.
-     *
-     * @param podName The name of the pod to wait for
-     */
-    private void checkPodCreation(String podName) throws Exception {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Checking pod " + podName);
-        }
-
-        Pod createdPod = k8sClient.pods()
-                .inNamespace(Constants.NAMESPACE)
-                .withName(podName)
-                .get();
-        if (createdPod == null || !createdPod.getMetadata().getName().equalsIgnoreCase(podName)) {
-            throw new Exception("Pod :" + podName + " is not created!");
-        }
-    }
-
-    /**
-     * Wait for a pod to be removed.
-     *
-     * @param podName The name of the pod to be deleted
-     */
-    private void waitForPodRemove(String podName) {
-        if (logger.isDebugEnabled()) {
-            logger.debug("Waiting for pod " + podName + " to be removed");
-        }
-        while (true) {
-            Pod pod = k8sClient.pods()
-                    .inNamespace(Constants.NAMESPACE)
-                    .withName(podName)
-                    .get();
-            if (pod == null) {
-                if (logger.isDebugEnabled()) {
-                    logger.debug("Removed pod " + podName);
-                }
-                break;
-            }
-            try {
-                Thread.sleep(1000);
-            } catch (InterruptedException ignored) {
-            }
-        }
+                .withStatus(status)
+                .build();
     }
 }

--- a/components/global/core/io.cellery.observability.k8s.client/src/test/java/io/cellery/observability/k8s/client/ComponentPodsEventSourceTestCase.java
+++ b/components/global/core/io.cellery.observability.k8s.client/src/test/java/io/cellery/observability/k8s/client/ComponentPodsEventSourceTestCase.java
@@ -1,0 +1,262 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.cellery.observability.k8s.client;
+
+import io.fabric8.kubernetes.api.model.Node;
+import org.apache.log4j.Logger;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+import org.wso2.extension.siddhi.map.keyvalue.sourcemapper.KeyValueSourceMapper;
+import org.wso2.siddhi.core.SiddhiAppRuntime;
+import org.wso2.siddhi.core.SiddhiManager;
+import org.wso2.siddhi.core.event.Event;
+import org.wso2.siddhi.core.query.output.callback.QueryCallback;
+import org.wso2.siddhi.core.util.EventPrinter;
+import org.wso2.siddhi.core.util.SiddhiTestHelper;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+
+/**
+ * Test case for Component Pod Event Source.
+ */
+public class ComponentPodsEventSourceTestCase extends BaseTestCase {
+
+    private static final Logger logger = Logger.getLogger(ComponentPodsEventSourceTestCase.class.getName());
+
+    private AtomicInteger eventCount = new AtomicInteger(0);
+    private List<String> nodeValues;
+    private SiddhiAppRuntime siddhiAppRuntime;
+    private List<Event> receivedEvents;
+
+    @BeforeClass
+    public void initTestCase() {
+        nodeValues = k8sClient.nodes()
+                .list()
+                .getItems()
+                .stream()
+                .map((Node node) -> node.getMetadata().getName())
+                .collect(Collectors.toList());
+        nodeValues.add("");
+    }
+
+    @BeforeMethod
+    public void init() {
+        eventCount.set(0);
+        receivedEvents = new ArrayList<>();
+    }
+
+    @AfterMethod
+    public void cleanUp() {
+        siddhiAppRuntime.shutdown();
+        if (logger.isDebugEnabled()) {
+            logger.debug("Removing all created test pods");
+        }
+        cleanUpTestPods();
+    }
+
+    @Test
+    public void testCreatePods() throws Exception {
+        initializeSiddhiAppRuntime();
+        createCelleryComponentPod("pet-be", "test-a");
+        createCelleryGatewayPod("pet-fe");
+
+        SiddhiTestHelper.waitForEvents(WAIT_TIME, 16, eventCount, TIMEOUT);
+        Map<String, String[]> podInfo = new HashMap<>();
+        Set<String> podStatuses = new HashSet<>();
+        Set<String> actions = new HashSet<>();
+        for (Event event : receivedEvents) {
+            Object[] data = event.getData();
+            Assert.assertEquals(data.length, 7);
+            validatePodData(data);
+            podInfo.put((String) data[2], new String[]{(String) data[0], (String) data[1]});
+            podStatuses.add((String) data[5]);
+            actions.add((String) data[6]);
+        }
+        assertEquals(podInfo, new HashMap<String, String[]>() {
+            {
+                put("pet-be--test-a", new String[]{"pet-be", "test-a"});
+                put("pet-fe--gateway", new String[]{"pet-fe", "gateway"});
+            }
+        });
+        assertEquals(podStatuses, new HashSet<>(Arrays.asList("Pending", "Running")));
+        assertEquals(actions, new HashSet<>(Arrays.asList("ADDED", "MODIFIED")));
+    }
+
+    @Test
+    public void testRemovePods() throws Exception {
+        createCelleryComponentPod("pet-be", "test-a");  // Missed event (will be replayed)
+        createCelleryComponentPod("pet-be", "test-b");  // Missed event (will be replayed)
+        initializeSiddhiAppRuntime();
+        createCelleryGatewayPod("pet-fe");
+        deletePod("pet-be--test-a");
+        deletePod("pet-fe--gateway");
+
+        SiddhiTestHelper.waitForEvents(WAIT_TIME, 8, eventCount, TIMEOUT);
+        // K8s server replays the missed events as well
+        Map<String, String[]> podInfo = new HashMap<>();
+        Set<String> podStatuses = new HashSet<>();
+        Set<String> actions = new HashSet<>();
+        for (Event event : receivedEvents) {
+            Object[] data = event.getData();
+            Assert.assertEquals(data.length, 7);
+            validatePodData(data);
+            podInfo.put((String) data[2], new String[]{(String) data[0], (String) data[1]});
+            podStatuses.add((String) data[5]);
+            actions.add((String) data[6]);
+            if ("DELETED".equals(data[6])) {
+                Assert.assertNotNull(data[6]);
+                Assert.assertNotEquals("", data[6]);
+            }
+        }
+        assertEquals(podInfo, new HashMap<String, String[]>() {
+            {
+                put("pet-be--test-a", new String[]{"pet-be", "test-a"});
+                put("pet-be--test-b", new String[]{"pet-be", "test-b"});
+                put("pet-fe--gateway", new String[]{"pet-fe", "gateway"});
+            }
+        });
+        assertEquals(podStatuses, new HashSet<>(Arrays.asList("Pending", "Running")));
+        assertEquals(actions, new HashSet<>(Arrays.asList("ADDED", "MODIFIED", "DELETED")));
+    }
+
+    @Test
+    public void testModifyPods() throws Exception {
+        initializeSiddhiAppRuntime();
+        createCelleryComponentPod("pet-be", "test-a");
+        k8sClient.pods()
+                .inNamespace(Constants.NAMESPACE)
+                .withName("pet-be--test-a")
+                .edit()
+                .editSpec()
+                .editFirstContainer()
+                .withNewImage("scratch")
+                .endContainer()
+                .endSpec()
+                .done();
+
+        SiddhiTestHelper.waitForEvents(WAIT_TIME, 8, eventCount, TIMEOUT);
+        // K8s server replays the missed events as well
+        Map<String, String[]> podInfo = new HashMap<>();
+        Set<String> podStatuses = new HashSet<>();
+        Set<String> actions = new HashSet<>();
+        for (Event event : receivedEvents) {
+            Object[] data = event.getData();
+            Assert.assertEquals(data.length, 7);
+            validatePodData(data);
+            podInfo.put((String) data[2], new String[]{(String) data[0], (String) data[1]});
+            podStatuses.add((String) data[5]);
+            actions.add((String) data[6]);
+        }
+        assertEquals(podInfo, new HashMap<String, String[]>() {
+            {
+                put("pet-be--test-a", new String[]{"pet-be", "test-a"});
+            }
+        });
+        assertEquals(podStatuses, new HashSet<>(Arrays.asList("Pending", "Running")));
+        assertEquals(actions, new HashSet<>(Arrays.asList("ADDED", "MODIFIED")));
+    }
+
+    /**
+     * Initialize the Siddhi App Runtime with the k8s
+     */
+    private void initializeSiddhiAppRuntime() {
+        String inStreamDefinition = "@App:name(\"test-siddhi-app\")\n" +
+                "@source(type=\"k8s-component-pods\", @map(type=\"keyvalue\", " +
+                "fail.on.missing.attribute=\"false\"))\n" +
+                "define stream k8sComponentPodsStream (cell string, component string, name string, " +
+                "creationTimestamp long, nodeName string, status string, action string);";
+        String query = "@info(name = \"query\")\n" +
+                "from k8sComponentPodsStream\n" +
+                "select *\n" +
+                "insert into outputStream;";
+        SiddhiManager siddhiManager = new SiddhiManager();
+        siddhiManager.setExtension("keyvalue", KeyValueSourceMapper.class);
+        siddhiAppRuntime = siddhiManager.createSiddhiAppRuntime(inStreamDefinition + "\n" + query);
+        siddhiAppRuntime.addCallback("query", new QueryCallback() {
+            @Override
+            public void receive(long timeStamp, Event[] inEvents, Event[] removeEvents) {
+                EventPrinter.print(timeStamp, inEvents, removeEvents);
+                for (Event event : inEvents) {
+                    synchronized (this) {
+                        receivedEvents.add(event);
+                    }
+                    eventCount.incrementAndGet();
+                }
+            }
+        });
+        siddhiAppRuntime.start();
+        if (logger.isDebugEnabled()) {
+            logger.debug("EventPrinter Initialized Siddhi App Runtime");
+        }
+    }
+
+    /**
+     * Validate the data from a pod event.
+     *
+     * @param data      The pod event data
+     */
+    private void validatePodData(Object[] data) {
+        Assert.assertNotNull(data[3]);
+        Assert.assertTrue(data[4] instanceof String);
+        Assert.assertNotEquals(nodeValues.indexOf(data[4]), -1);
+    }
+
+    /**
+     * Assert whether the two pod info maps are equal.
+     *
+     * @param actual The actual 2D array
+     * @param expected The expected 2D array
+     */
+    private void assertEquals(Map<String, String[]> actual, Map<String, String[]> expected) {
+        Assert.assertEquals(actual.size(), expected.size());
+        for (Map.Entry<String, String[]> expectedEntry : expected.entrySet()) {
+            String[] actualPodInfo = actual.get(expectedEntry.getKey());
+            String[] expectedPodInfo = expectedEntry.getValue();
+            Assert.assertNotNull(actualPodInfo, "expected pod info missing");
+            for (int i = 0; i < expectedPodInfo.length; i++) {
+                Assert.assertEquals(actualPodInfo[i], expectedPodInfo[i], "pod info does not match in pod " +
+                        expectedEntry.getKey());
+            }
+        }
+    }
+
+    /**
+     * Assert that two string sets are equal.
+     *
+     * @param actual   The actual string set
+     * @param expected The expected string set
+     */
+    private void assertEquals(Set<String> actual, Set<String> expected) {
+        Assert.assertEquals(actual.size(), expected.size());
+        for (String expectedValue : expected) {
+            Assert.assertTrue(actual.contains(expectedValue));
+        }
+    }
+}

--- a/components/global/core/io.cellery.observability.k8s.client/src/test/java/io/cellery/observability/k8s/client/K8sClientHolderTestCase.java
+++ b/components/global/core/io.cellery.observability.k8s.client/src/test/java/io/cellery/observability/k8s/client/K8sClientHolderTestCase.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.cellery.observability.k8s.client;
+
+import io.fabric8.kubernetes.client.KubernetesClient;
+import org.apache.log4j.Logger;
+import org.powermock.reflect.Whitebox;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * K8s Client test case.
+ */
+public class K8sClientHolderTestCase {
+
+    private static final Logger logger = Logger.getLogger(K8sClientHolderTestCase.class.getName());
+    @Test
+    public void testGetK8sClient() {
+        Whitebox.setInternalState(K8sClientHolder.class, "k8sClient", (KubernetesClient) null);
+        Assert.assertNotNull(K8sClientHolder.getK8sClient());
+    }
+
+    @Test
+    public void testGetK8sClientTwice() {
+        Whitebox.setInternalState(K8sClientHolder.class, "k8sClient", (KubernetesClient) null);
+        KubernetesClient k8sClient = K8sClientHolder.getK8sClient();
+        Assert.assertNotNull(k8sClient);
+        Assert.assertSame(K8sClientHolder.getK8sClient(), k8sClient);
+    }
+}

--- a/components/global/core/io.cellery.observability.k8s.client/src/test/java/io/cellery/observability/k8s/client/UtilsTestCase.java
+++ b/components/global/core/io.cellery.observability.k8s.client/src/test/java/io/cellery/observability/k8s/client/UtilsTestCase.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2019, WSO2 Inc. (http://www.wso2.org) All Rights Reserved.
+ *
+ * WSO2 Inc. licenses this file to you under the Apache License,
+ * Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package io.cellery.observability.k8s.client;
+
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.kubernetes.api.model.Pod;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Utilities test case.
+ */
+public class UtilsTestCase {
+
+    @Test
+    public void testGetComponentNameWithComponentLabel() {
+        Map<String, String> labels = new HashMap<>();
+        labels.put(Constants.COMPONENT_NAME_LABEL, "pet-fe--test-c");
+
+        ObjectMeta podMetadata = Mockito.mock(ObjectMeta.class);
+        Mockito.when(podMetadata.getLabels()).thenReturn(labels);
+        Pod pod = Mockito.mock(Pod.class);
+        Mockito.when(pod.getMetadata()).thenReturn(podMetadata);
+
+        Assert.assertEquals(Utils.getComponentName(pod), "test-c");
+    }
+
+    @Test
+    public void testGetComponentNameWithGatewayLabel() {
+        Map<String, String> labels = new HashMap<>();
+        labels.put(Constants.GATEWAY_NAME_LABEL, "pet-fe--test-d");
+
+        ObjectMeta podMetadata = Mockito.mock(ObjectMeta.class);
+        Mockito.when(podMetadata.getLabels()).thenReturn(labels);
+        Pod pod = Mockito.mock(Pod.class);
+        Mockito.when(pod.getMetadata()).thenReturn(podMetadata);
+
+        Assert.assertEquals(Utils.getComponentName(pod), "test-d");
+    }
+}

--- a/components/global/core/io.cellery.observability.k8s.client/src/test/java/io/cellery/observability/k8s/client/UtilsTestCase.java
+++ b/components/global/core/io.cellery.observability.k8s.client/src/test/java/io/cellery/observability/k8s/client/UtilsTestCase.java
@@ -36,11 +36,7 @@ public class UtilsTestCase {
     public void testGetComponentNameWithComponentLabel() {
         Map<String, String> labels = new HashMap<>();
         labels.put(Constants.COMPONENT_NAME_LABEL, "pet-fe--test-c");
-
-        ObjectMeta podMetadata = Mockito.mock(ObjectMeta.class);
-        Mockito.when(podMetadata.getLabels()).thenReturn(labels);
-        Pod pod = Mockito.mock(Pod.class);
-        Mockito.when(pod.getMetadata()).thenReturn(podMetadata);
+        Pod pod = generatePod(labels);
 
         Assert.assertEquals(Utils.getComponentName(pod), "test-c");
     }
@@ -48,13 +44,48 @@ public class UtilsTestCase {
     @Test
     public void testGetComponentNameWithGatewayLabel() {
         Map<String, String> labels = new HashMap<>();
-        labels.put(Constants.GATEWAY_NAME_LABEL, "pet-fe--test-d");
+        labels.put(Constants.GATEWAY_NAME_LABEL, "pet-fe--gateway");
+        Pod pod = generatePod(labels);
 
+        Assert.assertEquals(Utils.getComponentName(pod), "gateway");
+    }
+
+    @Test
+    public void testGetComponentNameWithNoLabels() {
+        Pod pod = generatePod(new HashMap<>());
+
+        Assert.assertEquals(Utils.getComponentName(pod), "");
+    }
+
+    @Test
+    public void testGetComponentNameWithInvalidComponentLabel() {
+        Map<String, String> labels = new HashMap<>();
+        labels.put(Constants.COMPONENT_NAME_LABEL, "pet-fe");
+        Pod pod = generatePod(labels);
+
+        Assert.assertEquals(Utils.getComponentName(pod), "");
+    }
+
+    @Test
+    public void testGetComponentNameWithInvalidGatewayLabel() {
+        Map<String, String> labels = new HashMap<>();
+        labels.put(Constants.GATEWAY_NAME_LABEL, "pet-fe");
+        Pod pod = generatePod(labels);
+
+        Assert.assertEquals(Utils.getComponentName(pod), "");
+    }
+
+    /**
+     * Generate a K8s Pod object.
+     *
+     * @param labels The labels to be applied to the Pod
+     * @return The generated pod
+     */
+    private Pod generatePod(Map<String, String> labels) {
         ObjectMeta podMetadata = Mockito.mock(ObjectMeta.class);
         Mockito.when(podMetadata.getLabels()).thenReturn(labels);
         Pod pod = Mockito.mock(Pod.class);
         Mockito.when(pod.getMetadata()).thenReturn(podMetadata);
-
-        Assert.assertEquals(Utils.getComponentName(pod), "test-d");
+        return pod;
     }
 }

--- a/components/global/core/io.cellery.observability.k8s.client/src/test/resources/log4j.properties
+++ b/components/global/core/io.cellery.observability.k8s.client/src/test/resources/log4j.properties
@@ -16,7 +16,7 @@
 # under the License.
 #
 
-log4j.rootLogger = DEBUG, console
+log4j.rootLogger = INFO, console
 log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.target=System.out
 log4j.appender.console.immediateFlush=true
@@ -24,3 +24,4 @@ log4j.appender.console.encoding=UTF-8
 log4j.appender.console.threshold=debug
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
 log4j.appender.console.layout.conversionPattern=%d [%t] %-5p %c - %m%n
+log4j.logger.io.cellery.observability.k8s.client=DEBUG, console

--- a/components/global/core/io.cellery.observability.siddhi.apps/src/main/siddhi/istio-telemetry-app.siddhi
+++ b/components/global/core/io.cellery.observability.siddhi.apps/src/main/siddhi/istio-telemetry-app.siddhi
@@ -103,8 +103,6 @@ define function extractFromUID[javascript] return string {
     } else if (uid === "Synapse-PT-HttpComponents-NIO") {
         if (index === 1) {
             extractedData = "global-gateway";
-        } else if (index === 2) {
-            extractedData = "cellery-system";
         }
     }
     return extractedData;

--- a/components/global/core/io.cellery.observability.siddhi.apps/src/main/siddhi/istio-telemetry-app.siddhi
+++ b/components/global/core/io.cellery.observability.siddhi.apps/src/main/siddhi/istio-telemetry-app.siddhi
@@ -77,6 +77,10 @@ define stream TelemetryStream(sourceUID string, sourceIP string, sourceLabels st
                               checkErrorCode long, checkErrorMessage string, checkCacheHit bool,
                               quotaCacheHit bool, contextReporterLocal bool);
 
+@source(type="inMemory", topic="k8s-component-pods", @map(type="passThrough"))
+define stream K8sComponentPodsInMemorySink(cell string, component string, name string, creationTimestamp long,
+                                           lastKnownAliveTimestamp long, nodeName string, status string, action string);
+
 @sink(type="inMemory", topic="istio-mixer-report", @map(type="passThrough"))
 define stream TelemetryInMemorySink(sourceNamespace string, sourceCell string, sourceComponent string,
                                     sourcePod string, destinationNamespace string, destinationCell string,
@@ -85,22 +89,30 @@ define stream TelemetryInMemorySink(sourceNamespace string, sourceCell string, s
                                     requestSizeBytes long, responseCode long, responseDurationNanoSec int,
                                     responseSizeBytes long);
 
+define window K8sComponentPodInfoWindow(podName string, cell string, component string) unique:time(podName, 11 minutes);
+
 define function extractFromUID[javascript] return string {
     var uid = data[0];
-    var index = data[1];    // 1: pod, 2: cell, 3: component, 4: namespace
+    var index = data[1];    // 1: pod, 2: namespace
 
-    var matches = /^(([a-z0-9-]+)--([a-z0-9-]+)-deployment-[a-z0-9]+-[a-z0-9]+)\.([a-z0-9-]+)$/.exec(uid);
+    var matches = /^([a-z0-9-.]+)\.([a-z0-9-]+)$/.exec(uid);
 
     var extractedData = "";
     if (matches) {
         extractedData = matches[index];
     } else if (uid === "Synapse-PT-HttpComponents-NIO") {
-        if (index === 3) {
+        if (index === 1) {
             extractedData = "global-gateway";
+        } else if (index === 2) {
+            extractedData = "cellery-system";
         }
     }
     return extractedData;
 };
+
+from K8sComponentPodsInMemorySink
+select name as podName, cell, component
+insert into K8sComponentPodInfoWindow;
 
 from TelemetryStream[(not sourceUID is null) and (not destinationUID is null)]
 select
@@ -110,10 +122,10 @@ select
     ifThenElse(requestHeaders is null, map:create(), map:createFromJSON(requestHeaders)) as requestHeadersMap,
     requestPath,
     requestMethod,
-    requestTotalSize,
+    requestTotalSize as requestSizeBytes,
     responseCode,
     responseDurationNanoSec,
-    responseTotalSize
+    responseTotalSize as responseSizeBytes
 insert into PreprocessedTelemetryStream;
 
 -- Storing the required attributes in a in memory sink (To be accessed from other siddhi apps)
@@ -122,20 +134,82 @@ insert into PreprocessedTelemetryStream;
 
 from PreprocessedTelemetryStream
 select
-    extractFromUID(sourceUID, 4) as sourceNamespace,
-    extractFromUID(sourceUID, 2) as sourceCell,
-    extractFromUID(sourceUID, 3) as sourceComponent,
+    extractFromUID(sourceUID, 2) as sourceNamespace,
     extractFromUID(sourceUID, 1) as sourcePod,
-    extractFromUID(destinationUID, 4) as destinationNamespace,
-    extractFromUID(destinationUID, 2) as destinationCell,
-    extractFromUID(destinationUID, 3) as destinationComponent,
+    extractFromUID(destinationUID, 2) as destinationNamespace,
     extractFromUID(destinationUID, 1) as destinationPod,
     contextReporterKind,
     requestHeadersMap,
     requestPath,
     requestMethod,
-    requestTotalSize as requestSizeBytes,
+    requestSizeBytes,
     responseCode,
     responseDurationNanoSec,
-    responseTotalSize as responseSizeBytes
+    responseSizeBytes
+insert into ProcessedTelemetryStream;
+
+-- Handling the special case of the global gateway
+
+from ProcessedTelemetryStream[sourcePod == "global-gateway"]
+select
+    sourceNamespace,
+    "" as sourceCell,
+    sourcePod as sourceComponent,
+    "" as sourcePod,
+    destinationNamespace,
+    "" as destinationCell,
+    sourcePod as destinationComponent,
+    "" as destinationPod,
+    contextReporterKind,
+    requestHeadersMap,
+    requestPath,
+    requestMethod,
+    requestSizeBytes,
+    responseCode,
+    responseDurationNanoSec,
+    responseSizeBytes
+insert into TelemetryInMemorySink;
+
+-- This is required since the filter processor is not a findable processor and therefore cannot be joined
+from ProcessedTelemetryStream[sourcePod != "global-gateway"]
+insert into NonGlobalGatewayProcessedTelemetryStream;
+
+from NonGlobalGatewayProcessedTelemetryStream as T inner join K8sComponentPodInfoWindow as K
+    on T.sourcePod == K.podName
+select
+    sourceNamespace,
+    K.cell as sourceCell,
+    K.component as sourceComponent,
+    sourcePod,
+    destinationNamespace,
+    destinationPod,
+    contextReporterKind,
+    requestHeadersMap,
+    requestPath,
+    requestMethod,
+    requestSizeBytes,
+    responseCode,
+    responseDurationNanoSec,
+    responseSizeBytes
+insert into SourceCellExtractedTelemetryStream;
+
+from SourceCellExtractedTelemetryStream as T inner join K8sComponentPodInfoWindow as K
+    on T.destinationPod == K.podName
+select
+    sourceNamespace,
+    sourceCell,
+    sourceComponent,
+    sourcePod,
+    destinationNamespace,
+    K.cell as destinationCell,
+    K.component as destinationComponent,
+    destinationPod,
+    contextReporterKind,
+    requestHeadersMap,
+    requestPath,
+    requestMethod,
+    requestSizeBytes,
+    responseCode,
+    responseDurationNanoSec,
+    responseSizeBytes
 insert into TelemetryInMemorySink;

--- a/components/global/core/io.cellery.observability.siddhi.apps/src/main/siddhi/k8s-telemetry-app.siddhi
+++ b/components/global/core/io.cellery.observability.siddhi.apps/src/main/siddhi/k8s-telemetry-app.siddhi
@@ -3,14 +3,57 @@
 
 define trigger K8sScrapeTrigger at every 10 min;
 
+@source(type="k8s-component-pods",
+        @map(type="keyvalue", fail.on.missing.attribute="false"))
+define stream K8sPodEventSourceStream(cell string, component string, name string, creationTimestamp long,
+                                      deletionTimestamp long, nodeName string, status string, action string);
+
+@sink(type="inMemory", topic="k8s-component-pods", @map(type="passThrough"))
+define stream K8sComponentPodsInMemorySink(cell string, component string, name string, creationTimestamp long,
+                                           lastKnownAliveTimestamp long, nodeName string, status string, action string);
+
 @Store(type="rdbms", datasource="CELLERY_OBSERVABILITY_DB")
 @PrimaryKey("cell", "component", "name")
 @purge(enable="false")
-define table K8sPodInfoTable (cell string, component string, name string, creationTimestamp long,
-                              lastKnownAliveTimestamp long, nodeName string);
+define table K8sPodInfoTable(cell string, component string, name string, creationTimestamp long,
+                             lastKnownAliveTimestamp long, nodeName string);
+
+define stream K8sComponentPodStream(cell string, component string, name string, creationTimestamp long,
+                                    lastKnownAliveTimestamp long, nodeName string, status string, action string);
+
+-- Collecting Pod info from different sources
+-- This collects Pod Info from the K8s watch as well as periodically by scraping K8s API Server
 
 from K8sScrapeTrigger#k8sClient:getComponentPods()
-select cell, component, name, creationTimestamp, triggered_time as lastKnownAliveTimestamp, nodeName
+select cell, component, name, creationTimestamp, triggered_time as lastKnownAliveTimestamp, nodeName, "Running" as status, "" as action
+insert into K8sComponentPodStream;
+
+from K8sPodEventSourceStream
+select cell, component, name, creationTimestamp, deletionTimestamp as lastKnownAliveTimestamp, nodeName, status, action
+insert into K8sComponentPodStream;
+
+-- Inserting Pod info to the K8sPodInfoTable
+
+from K8sComponentPodStream[action == "" or action == "DELETED"]
+select cell, component, name, creationTimestamp, lastKnownAliveTimestamp, nodeName
 update or insert into K8sPodInfoTable
     set K8sPodInfoTable.lastKnownAliveTimestamp = lastKnownAliveTimestamp
     on K8sPodInfoTable.cell == cell and K8sPodInfoTable.component == component and K8sPodInfoTable.name == name;
+
+from K8sComponentPodStream[action == "CREATED"]
+select cell, component, name, creationTimestamp, creationTimestamp as lastKnownAliveTimestamp, nodeName
+update or insert into K8sPodInfoTable
+    set K8sPodInfoTable.creationTimestamp = creationTimestamp, K8sPodInfoTable.nodeName = nodeName,
+        K8sPodInfoTable.lastKnownAliveTimestamp = lastKnownAliveTimestamp
+    on K8sPodInfoTable.cell == cell and K8sPodInfoTable.component == component and K8sPodInfoTable.name == name;
+
+from K8sComponentPodStream[action == "MODIFIED" or action == "ERROR"]
+select cell, component, name, creationTimestamp, time:timestampInMilliseconds() as lastKnownAliveTimestamp, nodeName
+update or insert into K8sPodInfoTable
+    set K8sPodInfoTable.lastKnownAliveTimestamp = lastKnownAliveTimestamp
+    on K8sPodInfoTable.cell == cell and K8sPodInfoTable.component == component and K8sPodInfoTable.name == name;
+
+-- Inserting the Pod Info events to the In Memory Sink to be read by the other Siddhi Apps
+
+from K8sComponentPodStream
+insert into K8sComponentPodsInMemorySink

--- a/components/global/core/io.cellery.observability.siddhi.apps/src/main/siddhi/tracing-app.siddhi
+++ b/components/global/core/io.cellery.observability.siddhi.apps/src/main/siddhi/tracing-app.siddhi
@@ -3,23 +3,23 @@
 
 @source(type="tracing-receiver", host="0.0.0.0", port="9411", api.context="/api/v1/spans",
         @map(type="keyvalue", fail.on.missing.attribute="false"))
-define stream ZipkinStreamIn (traceId string, id string, parentId string, name string, serviceName string,
-                              kind string, timestamp long, duration long, tags string);
+define stream ZipkinStreamIn(traceId string, id string, parentId string, name string, serviceName string,
+                             kind string, timestamp long, duration long, tags string);
 
 @source(type="inMemory", topic="istio-mixer-report", @map(type="passThrough"))
-define stream TelemetryStreamIn (sourceNamespace string, sourceCell string, sourceComponent string,
-                                 sourcePod string, destinationNamespace string, destinationCell string,
-                                 destinationComponent string, destinationPod string, contextReporterKind string,
-                                 requestHeadersMap object, requestPath string, requestMethod string,
-                                 requestSizeBytes long, responseCode long, responseDurationNanoSec int,
-                                 responseSizeBytes long);
+define stream TelemetryStreamIn(sourceNamespace string, sourceCell string, sourceComponent string,
+                                sourcePod string, destinationNamespace string, destinationCell string,
+                                destinationComponent string, destinationPod string, contextReporterKind string,
+                                requestHeadersMap object, requestPath string, requestMethod string,
+                                requestSizeBytes long, responseCode long, responseDurationNanoSec int,
+                                responseSizeBytes long);
 
 @Store(type="rdbms", datasource="CELLERY_OBSERVABILITY_DB", field.length="tags:8000")
 @PrimaryKey("traceId", "spanId", "kind")
 @purge(enable="false")
-define table DistributedTracingTable (traceId string, spanId string, parentId string, namespace string, cell string,
-                                      serviceName string, pod string, operationName string, kind string,
-                                      startTime long, duration long, tags string);
+define table DistributedTracingTable(traceId string, spanId string, parentId string, namespace string, cell string,
+                                     serviceName string, pod string, operationName string, kind string,
+                                     startTime long, duration long, tags string);
 
 define function extractFromServiceName[javascript] return string {
     var serviceName = data[0];

--- a/components/global/core/io.cellery.observability.tracing.receiver/src/test/resources/log4j.properties
+++ b/components/global/core/io.cellery.observability.tracing.receiver/src/test/resources/log4j.properties
@@ -16,7 +16,7 @@
 # under the License.
 #
 
-log4j.rootLogger = DEBUG, console
+log4j.rootLogger = INFO, console
 log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.target=System.out
 log4j.appender.console.immediateFlush=true
@@ -24,3 +24,4 @@ log4j.appender.console.encoding=UTF-8
 log4j.appender.console.threshold=debug
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
 log4j.appender.console.layout.conversionPattern=%d [%t] %-5p %c - %m%n
+log4j.logger.io.cellery.observability.tracing.receiver=DEBUG, console

--- a/pom.xml
+++ b/pom.xml
@@ -337,7 +337,7 @@
             </dependency>
             <dependency>
                 <groupId>org.powermock</groupId>
-                <artifactId>powermock-module-junit4</artifactId>
+                <artifactId>powermock-module-testng</artifactId>
                 <version>${powermock.version}</version>
                 <scope>test</scope>
             </dependency>


### PR DESCRIPTION
## Purpose
> Update the Cell and Component name resolution to use K8s labels taken from the API Servers to overcome the issue with long names causing the UUID to shrink.

## Goals
> Allow the user to observe component pods with long names.

## Approach
> A new Event Source is added to watch component pods to improve the accuracy of the Pod Information collected by the Stream Processor. The Siddhi Apps are changed to use the collected Pod info to resolve the Cell and Component name rather than using a regex to extract the information from the Pod name. This is done to avoid any potential issues with lng names causing the pod name to change.

## User stories
> As a user I need to provide long names to the component (ultimately to the pod names), and observe them without any issue.

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A