### PR TITLE
Add support to search for traces with pagination at server side

### DIFF
--- a/components/global/core/io.cellery.observability.api/src/main/java/io/cellery/observability/api/DistributedTracingAPI.java
+++ b/components/global/core/io.cellery.observability.api/src/main/java/io/cellery/observability/api/DistributedTracingAPI.java
@@ -213,7 +213,7 @@ public class DistributedTracingAPI {
                 rootSpanResults = new Object[0][0];
             }
 
-            Map<String, Object> resultsMap = new HashMap<>(2);
+            Map<String, Object> resultsMap = new HashMap<>(3);
             resultsMap.put("spanCounts", spanCountResults);
             resultsMap.put("rootSpans", rootSpanResults);
             resultsMap.put("totalRootSpansCount", fullTraceIdList.size());

--- a/components/global/core/io.cellery.observability.api/src/main/java/io/cellery/observability/api/siddhi/SiddhiStoreQueryTemplates.java
+++ b/components/global/core/io.cellery.observability.api/src/main/java/io/cellery/observability/api/siddhi/SiddhiStoreQueryTemplates.java
@@ -102,7 +102,8 @@ public enum SiddhiStoreQueryTemplates {
             "operationName == \"${" + Params.OPERATION_NAME + "}\") " +
             "and (${" + Params.MIN_DURATION + "}L == -1L or duration >= ${" + Params.MIN_DURATION + "}L)\n" +
             "select traceId\n" +
-            "group by traceId"
+            "group by traceId\n" +
+            "order by startTime desc"
     ),
     DISTRIBUTED_TRACING_SEARCH_GET_TRACE_IDS_WITH_TAGS("from DistributedTracingTable\n" +
             "on (\"${" + Params.INSTANCE + "}\" == \"\" or instance == \"${" + Params.INSTANCE + "}\") " +
@@ -111,14 +112,21 @@ public enum SiddhiStoreQueryTemplates {
             "and (\"${" + Params.OPERATION_NAME + "}\" == \"\" or " +
             "operationName == \"${" + Params.OPERATION_NAME + "}\") " +
             "and (${" + Params.MIN_DURATION + "}L == -1L or duration >= ${" + Params.MIN_DURATION + "}L)\n" +
-            "select traceId, tags"
+            "select traceId, tags\n" +
+            "order by startTime desc"
     ),
-    DISTRIBUTED_TRACING_SEARCH_GET_ROOT_SPAN_METADATA("from DistributedTracingTable\n" +
-            "on parentId is null and (${" + Params.CONDITION + "}) " +
-            "and (${" + Params.MAX_DURATION + "}L == -1L or duration <= ${" + Params.MAX_DURATION + "}L) " +
+    DISTRIBUTED_TRACING_SEARCH_GET_TRACE_IDS_WITH_VALID_ROOT_SPANS("from DistributedTracingTable\n" +
+            "on parentId is null " +
             "and (${" + Params.QUERY_START_TIME + "}L == -1L or startTime >= ${" + Params.QUERY_START_TIME + "}L) " +
             "and (${" + Params.QUERY_END_TIME + "}L == -1L or startTime <= ${" + Params.QUERY_END_TIME + "}L)\n" +
+            "select traceId\n" +
+            "group by traceId\n" +
+            "order by startTime desc"
+    ),
+    DISTRIBUTED_TRACING_SEARCH_GET_ROOT_SPAN_METADATA("from DistributedTracingTable\n" +
+            "on parentId is null and (${" + Params.CONDITION + "})\n" +
             "select traceId, instance, serviceName, operationName, startTime, duration\n" +
+            "group by traceId\n" +
             "order by startTime desc"
     ),
     DISTRIBUTED_TRACING_SEARCH_GET_MULTIPLE_INSTANCE_SERVICE_COUNTS("from DistributedTracingTable\n" +

--- a/components/global/core/io.cellery.observability.siddhi.apps/src/main/siddhi/tracing-app.siddhi
+++ b/components/global/core/io.cellery.observability.siddhi.apps/src/main/siddhi/tracing-app.siddhi
@@ -118,7 +118,10 @@ update or insert into DistributedTracingTable
 --
 
 -- Extracting information for local service
-from TelemetryStreamIn
+from TelemetryStreamIn[traceId != "" and spanId != ""]
+insert into FilteredTelemetryStreamIn;
+
+from FilteredTelemetryStreamIn
 select
     traceId,
     spanId,
@@ -131,7 +134,7 @@ select
 insert into ProcessedTelemetryDataStream;
 
 -- Extracting information for remote service
-from TelemetryStreamIn
+from FilteredTelemetryStreamIn
 select
     traceId,
     spanId,

--- a/components/global/portal/io.cellery.observability.ui/package-lock.json
+++ b/components/global/portal/io.cellery.observability.ui/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "io.cellery.observability.ui",
-  "version": "0.3.2-SNAPSHOT",
+  "version": "0.4.1-SNAPSHOT",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/components/global/portal/io.cellery.observability.ui/package.json
+++ b/components/global/portal/io.cellery.observability.ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cellery-io/observability-portal",
-  "version": "0.3.2-SNAPSHOT",
+  "version": "0.4.1-SNAPSHOT",
   "description": "Cellery Observability Portal",
   "author": "WSO2 Cellery Maintainers",
   "license": "Apache-2.0",

--- a/components/global/portal/io.cellery.observability.ui/src/components/tracing/search/TracesList.js
+++ b/components/global/portal/io.cellery.observability.ui/src/components/tracing/search/TracesList.js
@@ -134,11 +134,18 @@ class TracesList extends React.PureComponent {
     };
 
     handleChangeRowsPerPage = (event) => {
+        const {page, searchResults} = this.state;
         const rowsPerPage = event.target.value;
+
+        const maxPageCount = searchResults.totalRootSpansCount / rowsPerPage;
+        const highestPossiblePage = Number.isInteger(maxPageCount) ? maxPageCount - 1 : Math.floor(maxPageCount);
+
+        const newPage = page < highestPossiblePage ? page : highestPossiblePage;
         this.setState({
-            rowsPerPage: rowsPerPage
+            rowsPerPage: rowsPerPage,
+            page: newPage
         });
-        this.loadTraces(true, rowsPerPage, null);
+        this.loadTraces(true, rowsPerPage, newPage);
     };
 
     handleChangePage = (event, page) => {

--- a/components/global/portal/io.cellery.observability.ui/src/components/tracing/search/index.js
+++ b/components/global/portal/io.cellery.observability.ui/src/components/tracing/search/index.js
@@ -411,7 +411,7 @@ class TraceSearch extends React.Component {
 
     search = (isUserAction) => {
         if (this.tracesListRef.current && this.tracesListRef.current.loadTraces) {
-            this.tracesListRef.current.loadTraces(isUserAction);
+            this.tracesListRef.current.loadTraces(isUserAction, null, 0);
         }
     };
 

--- a/components/global/portal/io.cellery.observability.ui/src/utils/api/httpUtils.js
+++ b/components/global/portal/io.cellery.observability.ui/src/utils/api/httpUtils.js
@@ -61,7 +61,7 @@ class HttpUtils {
         let queryString = "";
         if (queryParams) {
             for (const [queryParamKey, queryParamValue] of Object.entries(queryParams)) {
-                if (!queryParamValue) {
+                if (queryParamValue === undefined || queryParamValue === null) {
                     continue;
                 }
 


### PR DESCRIPTION
## Purpose
> Fix wso2-cellery/sdk#755 -  Add support to search for traces with pagination at server side

## Goals
> Add support to search for traces with pagination at server side

## Approach
> Add support to search for traces with pagination at server side

## User stories
> N/A

## Release note
> N/A

## Documentation
> N/A

## Training
> N/A

## Certification
> N/A

## Marketing
> N/A

## Automation tests
 - Unit tests 
   > N/A
 - Integration tests
   > N/A

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? yes
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Samples
> N/A

## Related PRs
> N/A

## Migrations (if applicable)
> N/A

## Test environment
> N/A
 
## Learning
> N/A